### PR TITLE
Matrix build to test with multiple Python versions

### DIFF
--- a/.github/workflows/pythonapp.yml
+++ b/.github/workflows/pythonapp.yml
@@ -35,7 +35,7 @@ jobs:
     - name: store coverage report
       uses: actions/upload-artifact@v2
       with:
-        name: coverage-report
+        name: coverage-report-${{ matrix.python-version }}
         path: htmlcov/
     - name: Check for syntax errors and undefined names
       run: |


### PR DESCRIPTION
Testing with 3.7 to 3.9 covers the range from Debian stable to the latest stable Python release.