### PR TITLE
Limit workflow permissions

### DIFF
--- a/.github/workflows/pythonapp.yml
+++ b/.github/workflows/pythonapp.yml
@@ -2,6 +2,9 @@ name: exif_rename
 
 on: [push]
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Limiting the permissions of the token provided to the workflow is a recently-ish added feature. It's not critical considering we're only using official actions, but it's still good practice. :smiley_cat: 