### PR TITLE
Scaling script: Overwrite protection and command line options

### DIFF
--- a/scale_img_web.py
+++ b/scale_img_web.py
@@ -52,7 +52,10 @@ def scale_file(infile, size=(1280, 1280), date_format='%Y%m%d_%H%M%S'):
 
 if __name__ == '__main__':
     default_dateformat_help = exif_rename.default_dateformat.replace('%', '%%')
-    parser = argparse.ArgumentParser()
+    parser = argparse.ArgumentParser(
+        description='Scale images to certain maximum size (larger of width '
+        'or height), naming the output file after date and time information '
+        'from the original.')
 
     # Files to process
     parser.add_argument(
@@ -60,7 +63,7 @@ if __name__ == '__main__':
         help='List of files to process')
 
     parser.add_argument(
-        '-f', '--date-format', action='store', metavar='fmt',
+        '-f', '--date-format', action='store', metavar='FMT',
         help='Specify a custom date format (default '
         f'{default_dateformat_help}, see man (3) strftime for '
         'the format specification)')


### PR DESCRIPTION
Same concepts as for `exif_rename.py`:

* Append `-NUM` to make unique filenames
* Command line argument for date/time format, use `exif_rename` config file if present
* Command line option for the output size (max. of width and height)
